### PR TITLE
fix 2 typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install git+https://github.com/david-poirier-csn/pyheif.git
 
 ### Installing from source - Linux
 ```
-yum|apt install libheif-dev libde264-dev x265-dev
+yum|apt install libheif-dev libde265-dev libx265-dev
 pip install git+https://github.com/david-poirier-csn/pyheif.git
 ```
 


### PR DESCRIPTION
In the section Installing from source - Linux, it said libde264-dev instead of libde265-dev
Also in the ubuntu repo's the dev package for x265 is libx265-dev, not x265-dev