### PR TITLE
Support reading heif images from paths

### DIFF
--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -2,6 +2,7 @@ import glob
 import io
 import os
 import sys
+from pathlib import Path
 sys.path.insert(0, os.path.abspath('.'))
 
 import piexif
@@ -20,6 +21,17 @@ def test_read_file_names():
         assert(len(heif_file.data) > 0)
 
 
+def test_read_paths():
+    for fp in Path('tests/images').glob('*.heic'):
+        heif_file = pyheif.read_heif(fp)
+        assert(heif_file is not None)
+        assert(heif_file.mode in ['RGB', 'RGBA'])
+        width, height = heif_file.size
+        assert(width > 0)
+        assert(height > 0)
+        assert(len(heif_file.data) > 0)
+
+
 def test_read_file_objects():
     for fn in glob.glob('tests/images/*.heic'):
         with open(fn, 'rb') as f:
@@ -30,7 +42,7 @@ def test_read_file_objects():
             assert(width > 0)
             assert(height > 0)
             assert(len(heif_file.data) > 0)
-        
+
 def test_read_file_bytes():
     for fn in glob.glob('tests/images/*.heic'):
         with open(fn, 'rb') as f:
@@ -42,7 +54,7 @@ def test_read_file_bytes():
             assert(width > 0)
             assert(height > 0)
             assert(len(heif_file.data) > 0)
-        
+
 def test_read_file_bytearrays():
     for fn in glob.glob('tests/images/*.heic'):
         with open(fn, 'rb') as f:


### PR DESCRIPTION
Allow passing `pathlib.Path` instances to `pyheif.read_heif` function
for better developer experience.

ps. Sorry for stripping trailing spaces. It has been done automatically by editor on save due to my personal [.editorconfig](https://editorconfig.org)