### PR TITLE
Change HeifError base class from BaseException to Exception

### DIFF
--- a/pyheif/error.py
+++ b/pyheif/error.py
@@ -1,5 +1,5 @@
 
-class HeifError(BaseException):
+class HeifError(Exception):
     def __init__(self, *,
             code, subcode, message):
         self.code=code


### PR DESCRIPTION
The python document recommends using Exception instead of BaseException.

> The built-in exception classes can be subclassed to define new exceptions; programmers are encouraged to derive new exceptions from the Exception class or one of its subclasses, and not from BaseException. More information on defining exceptions is available in the Python Tutorial under User-defined Exceptions.

https://docs.python.org/3/library/exceptions.html