### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pip install git+https://github.com/david-poirier-csn/pyheif.git
 
 ### Installing from source - Linux
 ```
+sudo add-apt-repository ppa:strukturag/libheif
 apt install libffi libheif-dev libde265-dev
 ```
 or


### PR DESCRIPTION
The default `libheif` that comes with Ubuntu 18.04 does not work with the latest pyheif.

```shell
# Default libheif is 1.1.0
$ apt search libheif

Sorting... Done
Full Text Search... Done
libheif-dev/bionic,now 1.1.0-2 amd64 [installed]
  ISO/IEC 23008-12:2017 HEIF file format decoder - development files

libheif-examples/bionic 1.1.0-2 amd64
  ISO/IEC 23008-12:2017 HEIF file format decoder - examples

libheif1/bionic,now 1.1.0-2 amd64 [installed,automatic]
  ISO/IEC 23008-12:2017 HEIF file format decoder - shared library
```

Luckily the developer for `libheif` maintains an Ubuntu PPA with the latest build.